### PR TITLE
feat(infra): add scope_wide_registration for management-group-wide registration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+A published Terraform module — `ZouzIO/attribute-sensor/azurerm` on the Terraform Registry — that provisions the Azure side of the Attribute Sensor. Consumers reference it by version, so changes to the root module's public surface (variables, outputs) are API changes for downstream users.
+
+## Architecture
+
+The root module does two things on `apply`:
+
+1. **Provisions Azure resources** — resource group, a user-assigned managed identity, optionally a storage account + container, optionally a Cost Management export (`azapi_resource.export` using `Microsoft.CostManagement/exports@2023-07-01-preview` because the `azurerm` provider doesn't cover it), and role assignments (`Monitoring Reader` on the subscription, `Storage Blob Data Reader` on the storage account).
+2. **Registers the deployment with Attribute** — `data "http" "attribute_registration"` POSTs the resulting identity/storage details to `https://sensor.app.attrb.io/api/v1/azure`. This call has `depends_on` on the role assignments / federated credential / export so it only runs after Azure-side wiring is complete. The registration is part of the module's contract; treat it like a real resource even though it's an `http` data source.
+
+The managed identity is wired to Attribute's GCP service account via a **federated identity credential** with a hard-coded Google subject (`108313149922577077162`, issuer `https://accounts.google.com`). That's how Attribute's backend impersonates the identity to read Azure data — don't change it without coordinating with the backend.
+
+`create_costs_export = false` short-circuits a chain: storage account, container, blob-data-reader role assignment, the `azapi` export, and three fields in the registration POST all disappear. When editing, keep these in sync — every `count = var.create_costs_export ? 1 : 0` resource has matching conditionals in `registration.tf` and `outputs.tf`.
+
+`blob_storage_allowlist = true` flips the storage account to deny-by-default and allows two hardcoded IPs (`35.224.163.103`, `34.41.229.120`) — Attribute's GCP egress. It also flips the export to `SystemAssigned` identity so the export job can write through the firewall.
+
+`var.billing_account_id` overrides the export's `parent_id` (see `locals.export_scope`). The variable name is historical — it accepts any scope Cost Management exports support (billing account, management group, etc.) and is not validated. Default is the provider's subscription.
+
+`var.scope_wide_registration` (default `false`) flips the module into management-group-wide mode. When on:
+- `local.management_group_name` is parsed out of `billing_account_id` via regex on `/providers/Microsoft.Management/managementGroups/(.+)$` — bad input fails a precondition on `data.azurerm_management_group.this`.
+- `azurerm_role_assignment.subscription.scope` moves from the provider sub to `billing_account_id` so the role inherits to every child subscription.
+- `data.azurerm_subscription.registration` iterates over `data.azurerm_management_group.this[0].all_subscription_ids` (recursive — includes nested MGs) to fetch each sub's `tenant_id` / `display_name`.
+- `data.http.attribute_registration` is `for_each` over those subscriptions; cost-export fields are merged in only for the iteration whose key equals `data.azurerm_subscription.this.subscription_id` (the provider sub — the only one with an actual export).
+- A precondition on `azurerm_role_assignment.subscription` requires the provider sub to be a member of the MG. The single managed identity / storage account / export still live in the provider sub.
+
+## Submodule: `modules/databricks-integration`
+
+Standalone module (separate provider requirement: `databricks/databricks ~> 1.0`). Creates a Databricks service principal bound to the root module's managed identity, grants it `USE_CATALOG`/`USE_SCHEMA`/`SELECT` on `system.billing.usage`, and registers the workspace via a different endpoint: `https://sensor.app.attrb.io/api/v1/azure/databricks`. The `compute` variable supports either `SQL` (lookup via `databricks_sql_warehouse`) or `Cluster` (lookup via `databricks_cluster`); `locals.databricks_sql_endpoint` builds the correct JDBC path for each.
+
+## Common commands
+
+```powershell
+terraform fmt -recursive          # run before committing
+terraform init                    # in repo root or examples/simple
+terraform validate
+terraform plan
+pre-commit run --all-files        # runs terraform-docs on root + examples/simple
+terraform-docs .                  # regenerate README inputs/outputs table manually
+```
+
+To test changes locally, use `examples/simple` (it references the root via `source = "../.."`). It requires `organization_id` and `token` as inputs and uses an `azurerm` backend — supply backend config via `terraform init -backend-config=...`.
+
+## Conventions
+
+- **Don't hand-edit the `<!-- BEGIN_TF_DOCS -->` / `<!-- END_TF_DOCS -->` block in `README.md`** — terraform-docs (configured in `.terraform-docs.yml`, mode `inject`) regenerates it. Edit prose outside the markers, then run terraform-docs / pre-commit.
+- `moved` blocks in `moved.tf` migrate prior unindexed resources to `[0]` after introducing `count`. Preserve these when refactoring — removing them breaks upgrades for existing users.
+- Tag merging: every resource pulls tags via `local.<resource>_tags = merge(try(var.resource_tags["<key>"], {}), var.general_tags)`. New tagged resources should follow that pattern and add a matching `local`.
+- The module publishes telemetry through `modtm_module_source` (Azure's standard module-usage telemetry). The version/source are also included in the registration POST.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ In order to use this module, the user/service principal must have the following 
 - `Microsoft.CostManagement/exports/read`
 - `Microsoft.CostManagement/exports/write`
 
+When `scope_wide_registration = true`, the deploying principal additionally needs:
+- `Microsoft.Management/managementGroups/read` — used by the `azurerm_management_group` data source to enumerate child subscriptions.
+- `Microsoft.Authorization/roleAssignments/write` assignable at the target management group scope (the `Monitoring Reader` role assignment is created there instead of at the subscription).
+
 
 The following custom role can be used to assign the required permissions:
 ```hcl
@@ -76,11 +80,14 @@ resource "azurerm_role_definition" "attribute_sensor_terraform" {
   ]
 }
 ```
-## Providing the Billing Account ID
-By default, the Billing Export will be created at the subscription scope. If you want to create the export at the billing account scope, you need to provide the `billing_account_id` input variable, i.e.:
+## Overriding the Cost Management Export scope
+By default, the Cost Management Export is created at the provider's subscription scope. The `billing_account_id` input overrides this and is passed through as the export's `parent_id`, so it accepts any scope supported by Cost Management exports — for example a billing account or a management group.
 
-_`billing_account_id` must be in the format `/providers/Microsoft.Billing/billingAccounts/{billingAccountId}`, i.e. `/providers/Microsoft.Billing/billingAccounts/0000000-0000-0000-0000-000000000000:00000002-0002-0002-0002-000000000000_2019-05-31`_
+Examples of accepted formats:
+- Billing account: `/providers/Microsoft.Billing/billingAccounts/{billingAccountId}`, e.g. `/providers/Microsoft.Billing/billingAccounts/0000000-0000-0000-0000-000000000000:00000002-0002-0002-0002-000000000000_2019-05-31`
+- Management group: `/providers/Microsoft.Management/managementGroups/{managementGroupId}`, e.g. `/providers/Microsoft.Management/managementGroups/00000000-0000-0000-0000-000000000000`
 
+_Note: the input is named `billing_account_id` for backwards compatibility, but it is not validated as a billing-account ID — any valid export scope works._
 
 ```hcl
 module "attribute-sensor" {
@@ -108,6 +115,29 @@ module "attribute-sensor" {
 }
 ```
 In that case, only the Resource Group and Managed Identity will be created, skipping the Storage Account and Billing Export creation.
+## Registering all subscriptions under a management group
+By default the module registers only the provider's default subscription with Attribute and creates the `Monitoring Reader` role assignment at that subscription's scope. Setting `scope_wide_registration = true` switches the module to a management-group-wide mode:
+
+- The `Monitoring Reader` role assignment is created at the management group scope given by `billing_account_id`, so it inherits down to every child subscription.
+- The module enumerates every subscription under the management group recursively (via the `all_subscription_ids` attribute of `azurerm_management_group`, which includes subscriptions in nested management groups) and POSTs a registration to Attribute for each one.
+- Cost Management Export fields (`storage_container`, `storage_dir`, `storage_account_url`) are sent **only** in the registration for the provider's default subscription — that is the only subscription where the storage account and export resources are actually created.
+
+Requirements when this flag is on:
+- `billing_account_id` **must** be a management group resource ID in the form `/providers/Microsoft.Management/managementGroups/{name}`. A billing-account path will fail the precondition.
+- The provider's default subscription **must** be a member of the target management group (directly or via a child management group). The module fails fast otherwise.
+
+```hcl
+module "attribute-sensor" {
+  source  = "ZouzIO/attribute-sensor/azurerm"
+  version = "2.0.1"
+
+  organization_id = var.organization_id
+  token           = var.token
+
+  scope_wide_registration = true
+  billing_account_id      = "/providers/Microsoft.Management/managementGroups/00000000-0000-0000-0000-000000000000"
+}
+```
 ## Adding tags to created resources
 Two inputs can be used to add tags to the created resources:
 - `general_tags` - a map of tags to be added to all resources provisioned by the module
@@ -173,6 +203,8 @@ No modules.
 | [azurerm_storage_account.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account)                             | resource    |
 | [azurerm_storage_container.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container)                         | resource    |
 | [azurerm_user_assigned_identity.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity)               | resource    |
+| [azurerm_management_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/management_group)                        | data source |
+| [azurerm_subscription.registration](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription)                        | data source |
 | [azurerm_subscription.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription)                                | data source |
 | [http_http.attribute_registration](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http)                                    | data source |
 | [modtm_module_source.this](https://registry.terraform.io/providers/azure/modtm/latest/docs/data-sources/module_source)                                      | data source |
@@ -183,7 +215,7 @@ No modules.
 | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------------- | :------: |
 | <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id)                        | (**Required**) The Organization ID provided by Attribute.                                                                               | `string`           | n/a                 |   yes    |
 | <a name="input_token"></a> [token](#input\_token)                                                        | (**Required**) The token to authenticate with the Attribute API.                                                                        | `string`           | n/a                 |   yes    |
-| <a name="input_billing_account_id"></a> [billing\_account\_id](#input\_billing\_account\_id)             | (*Optional*) The Billing Account ID. If not provided, the Costs Export scope will be the providers subscription.                        | `string`           | `""`                |    no    |
+| <a name="input_billing_account_id"></a> [billing\_account\_id](#input\_billing\_account\_id)             | (*Optional*) The scope at which the Cost Management Export is created (used as the export's `parent_id`). Accepts any scope supported by Cost Management exports — e.g. a billing account (`/providers/Microsoft.Billing/billingAccounts/{id}`) or a management group (`/providers/Microsoft.Management/managementGroups/{id}`). If not provided, the export is created at the provider's subscription scope. | `string`           | `""`                |    no    |
 | <a name="input_blob_storage_allowlist"></a> [blob\_storage\_allowlist](#input\_blob\_storage\_allowlist) | (*Optional*) Whether to enforce the allowlist on the storage account. Defaults to false.                                                | `bool`             | `false`             |    no    |
 | <a name="input_cost_export_name"></a> [cost\_export\_name](#input\_cost\_export\_name)                   | (*Optional*) The name of the Cost Management Export. If not provided, a default name will be generated.                                 | `string`           | `"AttributeExport"` |    no    |
 | <a name="input_create_costs_export"></a> [create\_costs\_export](#input\_create\_costs\_export)          | (*Optional*) Whether to create the Cost Management Export. Defaults to true.                                                            | `bool`             | `true`              |    no    |
@@ -192,6 +224,7 @@ No modules.
 | <a name="input_managed_identity_name"></a> [managed\_identity\_name](#input\_managed\_identity\_name)    | (*Optional*) The name of the managed identity. If not provided, the managed identity name will be `Attribute`.                          | `string`           | `"Attribute"`       |    no    |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name)          | (*Optional*) The name of the resource group. If not provided, the resource group name will be `Attribute`.                              | `string`           | `"Attribute"`       |    no    |
 | <a name="input_resource_tags"></a> [resource\_tags](#input\_resource\_tags)                              | (*Optional*) Additional tags to apply to specific resources created by the module.                                                      | `map(map(string))` | `{}`                |    no    |
+| <a name="input_scope_wide_registration"></a> [scope\_wide\_registration](#input\_scope\_wide\_registration) | (*Optional*) When true, the `Monitoring Reader` role assignment is created at the scope given by `billing_account_id` (which must be a management group resource ID), and the module registers every subscription under that management group (recursively) with Attribute instead of only the provider's default subscription. Cost Management Export fields are only sent in the registration for the provider's default subscription. | `bool`             | `false`             |    no    |
 | <a name="input_storage_account_name"></a> [storage\_account\_name](#input\_storage\_account\_name)       | (*Optional*) The name of the storage account. If not provided, the storage account name will be extracted from the provider.            | `string`           | `""`                |    no    |
 | <a name="input_storage_container_name"></a> [storage\_container\_name](#input\_storage\_container\_name) | (*Optional*) The name of the storage container. If not provided, the storage container name will be generated from the subscription id. | `string`           | `"exports"`         |    no    |
 

--- a/data.tf
+++ b/data.tf
@@ -3,3 +3,20 @@ data "azurerm_subscription" "this" {}
 data "modtm_module_source" "this" {
   module_path = path.module
 }
+
+data "azurerm_management_group" "this" {
+  count = var.scope_wide_registration ? 1 : 0
+  name  = local.management_group_name
+
+  lifecycle {
+    precondition {
+      condition     = local.management_group_name != null
+      error_message = "When scope_wide_registration = true, billing_account_id must be a management group resource ID in the form /providers/Microsoft.Management/managementGroups/{name}."
+    }
+  }
+}
+
+data "azurerm_subscription" "registration" {
+  for_each        = toset(local.registration_subscription_ids)
+  subscription_id = each.key
+}

--- a/locals.tf
+++ b/locals.tf
@@ -6,6 +6,15 @@ locals {
   storage_account_name = var.storage_account_name == "" ? "attrb${substr(md5(data.azurerm_subscription.this.subscription_id), 0, 15)}" : var.storage_account_name
   export_scope         = var.billing_account_id != "" ? var.billing_account_id : data.azurerm_subscription.this.id
 
+  management_group_name = var.scope_wide_registration ? try(
+    regex("^/providers/Microsoft\\.Management/managementGroups/(.+)$", var.billing_account_id)[0],
+    null,
+  ) : null
+
+  principal_role_scope = var.scope_wide_registration ? var.billing_account_id : data.azurerm_subscription.this.id
+
+  registration_subscription_ids = var.scope_wide_registration ? data.azurerm_management_group.this[0].all_subscription_ids : [data.azurerm_subscription.this.subscription_id]
+
   resource_group_tags         = merge(try(var.resource_tags["resource_group"], {}), var.general_tags)
   storage_account_tags        = merge(try(var.resource_tags["storage_account"], {}), var.general_tags)
   user_assigned_identity_tags = merge(try(var.resource_tags["user_assigned_identity"], {}), var.general_tags)

--- a/main.tf
+++ b/main.tf
@@ -66,9 +66,19 @@ resource "azurerm_role_assignment" "storage_account" {
 
 resource "azurerm_role_assignment" "subscription" {
   for_each             = toset(local.principal_roles)
-  scope                = data.azurerm_subscription.this.id
+  scope                = local.principal_role_scope
   role_definition_name = each.key
   principal_id         = azurerm_user_assigned_identity.this.principal_id
+
+  lifecycle {
+    precondition {
+      condition = !var.scope_wide_registration || contains(
+        data.azurerm_management_group.this[0].all_subscription_ids,
+        data.azurerm_subscription.this.subscription_id,
+      )
+      error_message = "scope_wide_registration = true requires the provider's default subscription to be a member of the target management group (directly or via a child management group)."
+    }
+  }
 }
 
 resource "azapi_resource" "export" {

--- a/registration.tf
+++ b/registration.tf
@@ -1,4 +1,6 @@
 data "http" "attribute_registration" {
+  for_each = data.azurerm_subscription.registration
+
   request_headers = {
     "Content-Type"  = "application/json"
     "Authorization" = "Bearer ${var.token}"
@@ -11,9 +13,9 @@ data "http" "attribute_registration" {
     merge(
       {
         organization_id    = var.organization_id
-        tenant_id          = data.azurerm_subscription.this.tenant_id
-        subscription_id    = data.azurerm_subscription.this.subscription_id
-        subscription_name  = data.azurerm_subscription.this.display_name
+        tenant_id          = each.value.tenant_id
+        subscription_id    = each.value.subscription_id
+        subscription_name  = each.value.display_name
         client_id          = azurerm_user_assigned_identity.this.client_id
         billing_account_id = var.billing_account_id != "" ? var.billing_account_id : null
         module_info = {
@@ -21,7 +23,7 @@ data "http" "attribute_registration" {
           source  = data.modtm_module_source.this.module_source
         }
       },
-      var.create_costs_export ? {
+      (each.key == data.azurerm_subscription.this.subscription_id && var.create_costs_export) ? {
         storage_container   = azurerm_storage_container.this[0].name
         storage_dir         = "focus/${var.cost_export_name}"
         storage_account_url = azurerm_storage_account.this[0].primary_blob_endpoint

--- a/variables.tf
+++ b/variables.tf
@@ -16,8 +16,14 @@ variable "create_costs_export" {
 
 variable "billing_account_id" {
   type        = string
-  description = "(*Optional*) The Billing Account ID. If not provided, the Costs Export scope will be the providers subscription."
+  description = "(*Optional*) The scope at which the Cost Management Export is created (used as the export's `parent_id`). Accepts any scope supported by Cost Management exports — e.g. a billing account (`/providers/Microsoft.Billing/billingAccounts/{id}`) or a management group (`/providers/Microsoft.Management/managementGroups/{id}`). If not provided, the export is created at the provider's subscription scope."
   default     = ""
+}
+
+variable "scope_wide_registration" {
+  type        = bool
+  description = "(*Optional*) When true, the `Monitoring Reader` role assignment is created at the scope given by `billing_account_id` (which must be a management group resource ID), and the module registers every subscription under that management group (recursively) with Attribute instead of only the provider's default subscription. Cost Management Export fields are only sent in the registration for the provider's default subscription."
+  default     = false
 }
 
 variable "cost_export_name" {


### PR DESCRIPTION
## Summary
- Adds new bool input `scope_wide_registration` (default `false`). When on, the `Monitoring Reader` role assignment is created at the management group scope given by `billing_account_id`, and the module POSTs a registration for **every** subscription under that MG (recursive — uses `all_subscription_ids`, so subscriptions in nested management groups are included).
- Cost-export fields (`storage_container` / `storage_dir` / `storage_account_url`) are only sent in the registration for the provider's default subscription, since that's the only subscription where the storage account and export are actually created.
- Fails fast with preconditions when `billing_account_id` isn't a management group resource ID (form `/providers/Microsoft.Management/managementGroups/{name}`) or when the provider's default subscription isn't a member of the target MG.

## Behavior when `scope_wide_registration = false` (default)
Unchanged. Single registration POST for the provider's default subscription, role assignment at subscription scope. The only structural diff: `data.http.attribute_registration` is now `for_each`'d over a one-element set, so its address becomes `data.http.attribute_registration["{sub-id}"]`. Data sources don't carry state, so re-running the POST on first plan after upgrade is a no-op for downstream users.

## Files
- `variables.tf` — new `scope_wide_registration`.
- `locals.tf` — `management_group_name` (regex-parsed from `billing_account_id`), `principal_role_scope`, `registration_subscription_ids`.
- `data.tf` — counted `azurerm_management_group.this` with parsing precondition; `azurerm_subscription.registration` for_each.
- `main.tf` — `azurerm_role_assignment.subscription.scope` now `local.principal_role_scope`; precondition that the provider sub is a member of the MG.
- `registration.tf` — `data.http.attribute_registration` converted to `for_each`; cost-export fields merged in only for the provider's sub iteration.
- `README.md` — new "Registering all subscriptions under a management group" section, MG-specific required permissions, updated inputs / resources tables.
- `CLAUDE.md` — added (codebase docs for future Claude sessions; includes the new branch under "Architecture").

🤖 Generated with [Claude Code](https://claude.com/claude-code)